### PR TITLE
Fix to broken XPath tests

### DIFF
--- a/t/11_exp_to_xpath.t
+++ b/t/11_exp_to_xpath.t
@@ -99,19 +99,19 @@ E > F@foo
 --- exp
 E:first-child@foo
 --- xpath
-//*[1]/self::E/@foo
+//E[count(preceding-sibling::*) = 0 and parent::*]/@foo
 
 ===
 --- exp
 F E:first-child@foo
 --- xpath
-//F//*[1]/self::E/@foo
+//F//E[count(preceding-sibling::*) = 0 and parent::*]/@foo
 
 ===
 --- exp
 F > E:first-child@foo
 --- xpath
-//F/*[1]/self::E/@foo
+//F/E[count(preceding-sibling::*) = 0 and parent::*]/@foo
 
 ===
 --- exp
@@ -177,7 +177,7 @@ E#myid@foo
 --- exp
 E:nth-child(1)@foo
 --- xpath
-//E[count(preceding-sibling::*) = 0]/@foo
+//E[count(preceding-sibling::*) = 0 and parent::*]/@foo
 
 ===
 --- exp


### PR DESCRIPTION
HTML::Selector::XPath changed its output and handling of sibling and parent paths being more explicit (miyagawa/HTML-Selector-XPath@edf6810). The tests have been updated to match the ouput.  
