### PR TITLE
add failing TODO tests for HTML entities

### DIFF
--- a/t/05_value-type.t
+++ b/t/05_value-type.t
@@ -34,9 +34,9 @@ package main;
     <span>Booo!</span>
 </root>
 
-=== elem x scalarref
+=== elem x scalarref (TODO)
 --- vars
-'//span' => \'hey <b>you</b>!'
+'//span' => \'hey&mdash;<b>you</b>!'
 --- template
 <root>
     <div>
@@ -46,7 +46,7 @@ package main;
 --- expected
 <root>
     <div>
-        <span>hey <b>you</b>!</span>
+        <span>hey&mdash;<b>you</b>!</span>
     </div>
 </root>
 
@@ -338,16 +338,16 @@ use XML::LibXML;
     <span>xxx</span>
 </root>
 
-=== elem x sub (return scalarref)
+=== elem x sub (return scalarref) (TODO)
 --- vars
-'//span' => sub { \'<b>xx</b>x' }
+'//span' => sub { \'<b>xx</b>&mdash;x' }
 --- template
 <root>
     <span>bar</span>
 </root>
 --- expected
 <root>
-    <span><b>xx</b>x</span>
+    <span><b>xx</b>&mdash;x</span>
 </root>
 
 === elem x sub (return undef)
@@ -517,16 +517,16 @@ package main;
     <span title="xxx &gt; yyy">bar</span>
 </root>
 
-=== attr x scalar-ref
+=== attr x scalar-ref (TODO)
 --- vars
-'//span/@title' => \'<b>xxx</b> > yyy'
+'//span/@title' => \'<b>xxx</b> > yyy&sup2;'
 --- template
 <root>
     <span title="bar">bar</span>
 </root>
 --- expected
 <root>
-    <span title="xxx &gt; yyy">bar</span>
+    <span title="xxx &gt; yyy&sup2;">bar</span>
 </root>
 
 === attr x undef
@@ -708,16 +708,16 @@ use XML::LibXML;
     <span>xxx &gt; yyy</span>
 </div>
 
-=== text x scalar-ref
+=== text x scalar-ref (TODO)
 --- vars
-'//span/text()' => \'<b>xxx</b> > yyy'
+'//span/text()' => \'<b>xxx</b> > yyy&sup2;'
 --- template
 <root>
     <span>bar</span>
 </root>
 --- expected
 <root>
-    <span>xxx &gt; yyy</span>
+    <span>xxx &gt; yyy&sup2;</span>
 </root>
 
 === text x undef
@@ -899,16 +899,16 @@ use XML::LibXML;
     <!--xxx > yyy-->
 </div>
 
-=== comment x scalar-ref
+=== comment x scalar-ref (TODO)
 --- vars
-'//comment()[1]' => \'<b>xxx</b> > yyy'
+'//comment()[1]' => \'<b>xxx</b> > yyy&sup2;'
 --- template
 <root>
     <!-- foo -->
 </root>
 --- expected
 <root>
-    <!--<b>xxx</b> > yyy-->
+    <!--<b>xxx</b> > yyy&sup2;-->
 </root>
 
 === comment x undef
@@ -1090,16 +1090,16 @@ use XML::LibXML;
     <![CDATA[xxx > yyy]]>
 </div>
 
-=== cdata x scalar-ref
+=== cdata x scalar-ref (TODO)
 --- vars
-'//text()[2]' => \'<b>xxx</b> > yyy'
+'//text()[2]' => \'<b>xxx</b> > yyy&sup2;'
 --- template
 <root>
     <![CDATA[ foo ]]>
 </root>
 --- expected
 <root>
-    <![CDATA[<b>xxx</b> > yyy]]>
+    <![CDATA[<b>xxx</b> > yyy&sup2;]]>
 </root>
 
 === cdata x undef


### PR DESCRIPTION
This pull request includes updated tests showing a failure in `Template::Semantic` to properly handle HTML entities, as discussed in [issue #4](https://github.com/tomi-ru/Template-Semantic/issues/4).

Unfortunately, having briefly looked at the code for `Template::Semantic::Document` I don't know how to fix this problem.  It seems that the `parse_string` method in `XML::LibXML::Parser` is being called, and this method is responsible for silently removing the HTML entities.  A `parse_html_string` method exists, but swapping that for `parse_string` doesn't appear to solve the problem.
