### PR TITLE
Fixed test 11_exp_to_xpath.t

### DIFF
--- a/t/11_exp_to_xpath.t
+++ b/t/11_exp_to_xpath.t
@@ -51,7 +51,7 @@ __DATA__
 --- exp
 .foo
 --- xpath
-//*[contains(concat(' ', @class, ' '), ' foo ')]
+//*[contains(concat(' ', normalize-space(@class), ' '), ' foo ')]
 
 ===
 --- exp
@@ -135,7 +135,7 @@ E + #bar@foo
 --- exp
 E + .bar@foo
 --- xpath
-//E/following-sibling::*[1]/self::*[contains(concat(' ', @class, ' '), ' bar ')]/@foo
+//E/following-sibling::*[1]/self::*[contains(concat(' ', normalize-space(@class), ' '), ' bar ')]/@foo
 
 ===
 --- exp
@@ -165,7 +165,7 @@ E[lang|="en"]@foo
 --- exp
 DIV.warning@foo
 --- xpath
-//DIV[contains(concat(' ', @class, ' '), ' warning ')]/@foo
+//DIV[contains(concat(' ', normalize-space(@class), ' '), ' warning ')]/@foo
 
 ===
 --- exp


### PR DESCRIPTION
Fixed 11_exp_to_xpath.t - respecting changes in HTML-Selector-XPath between 0.16 and 0.17
-                push @parts, "[contains(concat(' ', \@class, ' '), ' $name ')]";
-                push @parts, "[contains(concat(' ', normalize-space(\@class), ' '), ' $name ')]";

see https://metacpan.org/diff/file?target=CORION/HTML-Selector-XPath-0.17/lib/HTML/Selector/XPath.pm&source=CORION/HTML-Selector-XPath-0.16/lib/HTML/Selector/XPath.pm
